### PR TITLE
Reorient to prefer bulk at the bottom when wrapping

### DIFF
--- a/MMM-Powerwall.css
+++ b/MMM-Powerwall.css
@@ -14,7 +14,14 @@
 
 .MMM-Powerwall.flexbox {
     display: flex;
-    flex-wrap: wrap; 
+    flex-wrap: nowrap;
+    justify-content: space-evenly;
+}
+
+.MMM-Powerwall.rflexbox {
+    display: flex;
+    flex-wrap: wrap-reverse;
+    flex-direction: row-reverse;
     justify-content: space-evenly;
 }
 

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -111,6 +111,9 @@ Module.register("MMM-Powerwall", {
 			this.sendSocketNotification("Enable-Debug");
 		}
 
+		// Reverse graphs to accomodate wrap-reverse
+		this.config.graphs.reverse();
+
 		let callsToEnable = new Set();
 		this.config.graphs.forEach(
 			graph => REQUIRED_CALLS[graph].forEach(

--- a/MMM-Powerwall.njk
+++ b/MMM-Powerwall.njk
@@ -1,4 +1,4 @@
-<div class="MMM-Powerwall flexbox">
+<div class="MMM-Powerwall rflexbox">
 {% for graph in config.graphs %}
     <div class="module MMM-Powerwall module-content flexitem">
         {% if graph == "SolarProduction" -%}


### PR DESCRIPTION
This changes the wrapping logic so that if there is space for 4 graphs across and 6 are displayed, it displays as:

     1   2
    3 4 5 6

Instead of:

    1 2 3 4
     5   6

This can be made configurable, if someone prefers the old layout.  Alternatively, override the CSS change in your `custom.css` file; you may also need to reverse the order of the graphs in your `config.js` file if you do that.