### PR TITLE
Use local-only SOE with adjustment factor

### DIFF
--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -261,7 +261,7 @@ Module.register("MMM-Powerwall", {
 	},
 
 	updateStormWatch: function() {
-		if( this.callsToEnable.stormWatch ) {
+		if( this.callsToEnable.storm ) {
 			this.Log("Requesting Storm Watch state");
 			this.sendDataRequestNotification("UpdateStormWatch");
 		}

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -161,10 +161,7 @@ Module.register("MMM-Powerwall", {
 				powerwallIP: config.powerwallIP,
 				twcManagerIP: config.twcManagerIP,
 				twcManagerPort: config.twcManagerPort,
-				updateInterval: config.localUpdateInterval - 500,
-				username: config.teslaAPIUsername,
-				siteID: config.siteID,
-				resyncInterval: config.cloudUpdateInterval - 500
+				updateInterval: config.localUpdateInterval - 500
 			});
 			this.doTimeout("local", () => self.updateLocal(), this.config.localUpdateInterval);
 		}

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -18,7 +18,7 @@ const REQUIRED_CALLS = {
 	HouseConsumption: ["local", "energy"],
 	EnergyBar: ["local", "energy"],
 	PowerLine: ["power"],
-	Grid: ["local", "energy"]
+	Grid: ["local", "energy", "storm"]
 }
 
 const DISPLAY_SOURCES = [
@@ -263,6 +263,13 @@ Module.register("MMM-Powerwall", {
 		}
 	},
 
+	updateStormWatch: function() {
+		if( this.callsToEnable.stormWatch ) {
+			this.Log("Requesting Storm Watch state");
+			this.sendDataRequestNotification("UpdateStormWatch");
+		}
+	},
+
 	updateVehicleData: function(timeout=null) {
 		if( this.callsToEnable.vehicle ) {
 			let now = Date.now();
@@ -309,9 +316,11 @@ Module.register("MMM-Powerwall", {
 						this.updateEnergy();
 						this.updateSelfConsumption();
 						this.updatePowerHistory();
+						this.updateStormWatch();
 						this.doTimeout("cloud", () => {
 							self.updateSelfConsumption();
 							self.updatePowerHistory();
+							self.updateStormWatch();
 						}, this.config.cloudUpdateInterval);
 					}
 					this.updateLocal();
@@ -360,7 +369,7 @@ Module.register("MMM-Powerwall", {
 						false);
 					let meterNode = document.getElementById(this.identifier + "-battery-meter");
 					if (meterNode) {
-						meterNode.style = "height: " + payload.soe + "%;";
+						meterNode.style = "height: " + Math.min(100, payload.soe) + "%;";
 					}
 				}
 				break;

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -366,7 +366,7 @@ Module.register("MMM-Powerwall", {
 						false);
 					let meterNode = document.getElementById(this.identifier + "-battery-meter");
 					if (meterNode) {
-						meterNode.style = "height: " + Math.min(100, payload.soe) + "%;";
+						meterNode.style = "height: " + payload.soe + "%;";
 					}
 				}
 				break;


### PR DESCRIPTION
Someone on Reddit helpfully pointed out the adjustment formula for cloud vs. local SOE values, so we can eliminate the hack of using the cloud value and adjusting it with the local changes until we resync.  This should be a neutral change for anyone using cloud data, but will result in properly-adjusted values for anyone using local-only data.

It also has the interesting side-effect that the "extra capacity" of the Powerwall can show in the module now.  That is, it's now possible for SOE to be negative if the Powerwall is discharged below its intended functional reserves.  (Though I suspect if the situation is that dire, you've turned off the magic mirror.)