### PR TITLE
Car polling while suspended

### DIFF
--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -522,13 +522,11 @@ Module.register("MMM-Powerwall", {
 
 				if( payload.username === this.config.teslaAPIUsername ) {
 					let intervalToUpdate = this.config.cloudUpdateInterval;
-					let exempt = true;
 					if( payload.state === "online" && payload.drive.gear === "D" ) {
 						intervalToUpdate = 2*this.config.localUpdateInterval + this.config.cloudUpdateInterval;
 						intervalToUpdate /= 3;
-						exempt = false;
 					}
-					this.doTimeout("vehicle", () => self.updateVehicleData(), intervalToUpdate, exempt);
+					this.doTimeout("vehicle", () => self.updateVehicleData(), intervalToUpdate, true);
 
 					let statusFor = (this.vehicles || []).find(vehicle => vehicle.id == payload.ID);
 					if( !statusFor ) {
@@ -610,7 +608,7 @@ Module.register("MMM-Powerwall", {
 			target: Date.now() + delay,
 			exempt: exempt
 		};
-		if( !this.suspended || !exempt ) {
+		if( !this.suspended || exempt ) {
 			this.timeouts[name].handle = setTimeout(() => func(), delay);
 		}
 	},

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -627,7 +627,9 @@ Module.register("MMM-Powerwall", {
 	suspend: function() {
 		this.suspended = true;
 		for( let name in this.timeouts ) {
-			clearTimeout(this.timeouts[name].handle)
+			if( !this.timeouts[name].exempt ) {
+				clearTimeout(this.timeouts[name].handle);
+			}
 		}
 	},
 

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -279,6 +279,8 @@ Module.register("MMM-Powerwall", {
 			if( Array.isArray(this.vehicles) ) {
 				for( let vehicle of this.vehicles) {
 					if( willingToDefer && vehicle.deferUntil && now < vehicle.deferUntil) {
+						let self = this;
+						this.doTimeout("vehicle", () => self.updateVehicleData(), vehicle.deferUntil - now + 1000, true);
 						continue;
 					}
 


### PR DESCRIPTION
All other polling can stop while suspended, because the Powerwall and the API are always online to get back in sync later.  However, the API can't tell us about the car if the car is offline; if we stay suspended through a car wake-up or charging cycle, we might miss something.

This change should make vehicle polling more reliable, at the expense of it continuing while asleep.