### PR TITLE
Auth v3 support, password only

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ This module relies on being able to access your Powerwall both locally and via
 the Tesla API.  The local endpoint interactions require no authentication. To
 authenticate to the Tesla API, you have two options:
 
-- ~~**Include your password in the module configuration.**
+- **Include your password in the module configuration.**
   Note that your password will be relayed from client to server at client
   start-up and MagicMirror2 does not use TLS by default, so use this option only
   if your only client is on the same device, or if you completely trust your
-  local network.~~
+  local network.
 - **Generate Tesla API tokens yourself.**
   Create a file named `tokens.json` in the module directory containing the
   following:
@@ -98,13 +98,19 @@ authenticate to the Tesla API, you have two options:
   - `DATE HERE` is the approximate timestamp of when the tokens were generated;
     you can run `date +%s` from a Linux command line to get this.
 
-~~Alternatively, the module will generate `tokens.json` after the first successful
-load with the password in the config.  You can remove the password from your
-`config.js` file afterward, and it will continue to work (unless you change your
-password, which invalidates all existing tokens).  If using multiple instances,
-providing the password to any instance enables all instances to use it.~~
+However, because of the way refresh tokens are handled in the new Authentication
+model, this does not permit automatic refresh of the token.  **You may need to
+manually supply a fresh token every 45 days if you use this option.**
 
-Password authentication is currently broken, but will return soon.
+If a password is provided, the module will generate `tokens.json` with a
+working refresh token after the first successful load with the password in the
+config.  You can then remove the password from your `config.js` file afterward,
+and it will continue to work (unless you change your password, which invalidates
+all existing tokens).  If using multiple instances, providing the password to
+any instance enables all instances to use it.
+
+Multi-factor authentication is not yet supported, but will be in the near
+future.
 
 Neither the password nor the tokens are sent anywhere except from your client to
 the node_helper, and thence to the Tesla API.
@@ -125,3 +131,4 @@ In addition to any commiters to the repo, the following have helped figure certa
 
 - @ngardiner's work on TWCManager is amazing, and the car charging could not be tracked without it
 - @Kemmey provided initial code for interacting with the compositor
+- Access to Tesla's v3 authentication endpoint adapted from @jorenvandeweyer's implementation

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "chart.js": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
@@ -58,7 +66,21 @@
     "commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true
+    },
+    "crypto-random-string": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.0.tgz",
+      "integrity": "sha512-teWAwfMb1d6brahYyKqcBEb5Yp8PJPvPOdOonXDnvaKOTmKDFNVE8E3Y2XQuzjNV/3XMwHbrX9fHWvrhRKt4Gg==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "moment": {
       "version": "2.25.3",
@@ -74,9 +96,31 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pseudoloc-js/-/pseudoloc-js-1.2.2.tgz",
       "integrity": "sha512-6YS83rbUY1O25YQinDvcnsk9e09qOfMvcfXRXDZRND/UYy1uh4oGihhCnGpVdqN3jOKBnEyq2sbyxbRKP6BLxw==",
+      "dev": true,
       "requires": {
         "commander": "*"
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
+    "urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
   "author": "Mike Bishop",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.21.1",
     "chart.js": "latest",
     "chartjs-plugin-datalabels": "^0.7.0",
-    "node-fetch": "^2.6.1"
+    "crypto-random-string": "^3.3.0",
+    "node-fetch": "^2.6.1",
+    "querystring": "^0.2.0",
+    "urlsafe-base64": "^1.0.0"
   },
   "devDependencies": {
-    "pseudoloc-js": "^1.2.2"
+    "pseudoloc-js": "^1.2.2",
+    "typescript": "^4.1.3"
   }
 }

--- a/tesla-oauth-v3.js
+++ b/tesla-oauth-v3.js
@@ -1,0 +1,183 @@
+/* eslint-disable camelcase */
+var axios = require('axios');
+var crypto = require('crypto');
+var qs = require('querystring');
+var urlsafebase64 = require('urlsafe-base64');
+var cryptoRandomString = require('crypto-random-string');
+var toughcookie = require('tough-cookie');
+var events = require('events');
+const CLIENT_ID = '81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384';
+
+module.exports = {
+    Authenticator: class extends events.EventEmitter {
+        constructor() {
+            super();
+            this.jar = new toughcookie.CookieJar();
+            this.http = axios.create({
+                maxRedirects: 0,
+                validateStatus: (status) => {
+                    return (status >= 200 && status < 300) || status === 302;
+                }
+            });
+            this.http.interceptors.request.use(config => {
+                this.jar.getCookies(config.url, {}, (err, cookies) => {
+                    if (err)
+                        return;
+                    config.headers.cookie = cookies.join('; ');
+                });
+                return config;
+            });
+            this.http.interceptors.response.use(response => {
+                if (response.headers['set-cookie'] instanceof Array) {
+                    response.headers['set-cookie'].forEach(c => {
+                        this.jar.setCookie(toughcookie.Cookie.parse(c), response.config.url, () => { });
+                    });
+                }
+                return response;
+            });
+        }
+        async login(username, password, mfaCode) {
+            var _a;
+            if (!this.parameters)
+                this.generateParameters();
+            let body;
+            try {
+                const hidden = await this.scrapeOauthForm();
+                body = {
+                    _csrf: hidden.csrf,
+                    _phase: hidden.phase,
+                    _process: hidden.process,
+                    transaction_id: hidden.transactionId,
+                    cancel: hidden.cancel,
+                    identity: username,
+                    credential: password
+                };
+            }
+            catch (e) {
+                return this.emit('error', 'scraping oauth form failed');
+            }
+            let res;
+            try {
+                res = await this.http.post(this.oauth2url, qs.stringify(body), {
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    }
+                });
+            }
+            catch (e) {
+                return this.emit('error', 'invalid credentials');
+            }
+            if (res.status === 200 && ((_a = res.data) === null || _a === void 0 ? void 0 : _a.includes('/mfa/verify'))) {
+                if (!mfaCode)
+                    return this.emit('mfa');
+                else
+                    return await this.mfaCode(mfaCode);
+            }
+            else {
+                this.parseCallback(res.headers.location);
+                return await this.exchangeCode();
+            }
+        }
+        async mfaCode(mfaCode) {
+            var _a, _b, _c, _d;
+            const url = `https://auth.tesla.com/oauth2/v3/authorize/mfa/factors?transaction_id=${this.transactionId}`;
+            const res1 = await this.http.get(url);
+            const factorId = res1.data.data[0].id;
+            const mfaPayload = {
+                transaction_id: this.transactionId, factor_id: factorId, passcode: mfaCode
+            };
+            try {
+                const res = await this.http.post('https://auth.tesla.com/oauth2/v3/authorize/mfa/verify', mfaPayload);
+                if (!((_a = res === null || res === void 0 ? void 0 : res.data) === null || _a === void 0 ? void 0 : _a.data.valid))
+                    return this.emit('error', 'invalid mfaCode');
+            }
+            catch (e) {
+                return this.emit('error', (_d = (_c = (_b = e === null || e === void 0 ? void 0 : e.response) === null || _b === void 0 ? void 0 : _b.data) === null || _c === void 0 ? void 0 : _c.error) === null || _d === void 0 ? void 0 : _d.code);
+            }
+            const res2 = await this.http.post(this.oauth2url, { transaction_id: this.transactionId });
+            this.parseCallback(res2.headers.location);
+            return await this.exchangeCode();
+        }
+        async refresh(refreshToken) {
+            const payload = {
+                grant_type: 'refresh_token',
+                client_id: 'ownerapi',
+                refresh_token: refreshToken,
+                scope: 'openid email offline_access'
+            };
+            const res = await this.http.post('https://auth.tesla.com/oauth2/v3/token', payload);
+            const ownerApi = await this.ownerApiToken(res.data.access_token);
+            const tokens = {
+                auth: res.data,
+                ownerApi
+            };
+            this.emit('ready', tokens);
+            return tokens;
+        }
+        async ownerApiToken(accessToken) {
+            const payload = {
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                client_id: CLIENT_ID
+            };
+            const res = await this.http.post('https://owner-api.teslamotors.com/oauth/token', payload, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`
+                }
+            });
+            return res.data;
+        }
+        async exchangeCode() {
+            const payload = {
+                grant_type: 'authorization_code',
+                client_id: 'ownerapi',
+                code_verifier: this.codeVerifier,
+                code: this.code,
+                redirect_uri: 'https://auth.tesla.com/void/callback'
+            };
+            const res = await this.http.post('https://auth.tesla.com/oauth2/v3/token', payload);
+            const ownerApi = await this.ownerApiToken(res.data.access_token);
+            const tokens = {
+                auth: res.data,
+                ownerApi
+            };
+            this.emit('ready', tokens);
+            return tokens;
+        }
+        generateParameters() {
+            this.codeVerifier = urlsafebase64.encode(Buffer.from(cryptoRandomString({ length: 86 }), 'utf-8')).trim();
+            const hash = crypto.createHash('sha256').update(this.codeVerifier).digest('hex');
+            const codeChallenge = urlsafebase64.encode(Buffer.from(hash, 'utf8')).trim();
+            const state = urlsafebase64.encode(crypto.randomBytes(16));
+            this.parameters = {
+                client_id: 'ownerapi',
+                code_challenge: codeChallenge,
+                code_challenge_method: 'S256',
+                redirect_uri: encodeURIComponent('https://auth.tesla.com/void/callback'),
+                response_type: 'code',
+                scope: encodeURIComponent('openid email offline_access'),
+                state: state
+            };
+        }
+        async scrapeOauthForm() {
+            const res = await this.http.get(this.oauth2url);
+            const match = (data, regex) => {
+                const m = data.match(regex);
+                return m ? m[1] : '';
+            };
+            const csrf = match(res.data, /name="_csrf".+value="([^"]+)"/);
+            const transactionId = match(res.data, /name="transaction_id".+value="([^"]+)"/);
+            const phase = match(res.data, /name="_phase".+value="([^"]+)"/);
+            const process = match(res.data, /name="_process".+value="([^"]+)"/);
+            const cancel = match(res.data, /name="cancel".+value="([^"]+)"/);
+            this.transactionId = transactionId;
+            return { csrf, transactionId, phase, process, cancel };
+        }
+        parseCallback(location) {
+            const url = new URL(location);
+            this.code = url.searchParams.get('code');
+        }
+        get oauth2url() {
+            return `https://auth.tesla.com/oauth2/v3/authorize?client_id=${this.parameters.client_id}&code_challenge=${this.parameters.code_challenge}&code_challenge_method=${this.parameters.code_challenge_method}&redirect_uri=${this.parameters.redirect_uri}&response_type=${this.parameters.response_type}&scope=${this.parameters.scope}&state=${this.parameters.state}`;
+        }
+    }
+}


### PR DESCRIPTION
Second part of #36; implements support for password-only auth in the new flow.  Existing tokens will continue to work, but will not successfully refresh.  If you supply the password in `config.js`, this will get a fresh token and should successfully refresh in the future.

tesla-oauth-v3.js is taken almost entirely from @jorenvandeweyer's sample; many thanks.