### PR TITLE
Scale PowerLine for bursty graphs

### DIFF
--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -1897,10 +1897,10 @@ Module.register("MMM-Powerwall", {
 							type: "linear",
 							ticks: {
 								callback: function (value, index, values) {
-									if (value % 1000 == 0) {
-										value = Math.abs(value);
+									let clip = this._userMax;
+									value = Math.abs(value);
+									if (value % 1000 == 0 || value == clip) {
 										let result = value / 1000;
-										let clip = this.max;
 										if (clip && value >= clip) {
 											result = ">" + result;
 										}
@@ -2034,9 +2034,10 @@ Module.register("MMM-Powerwall", {
 			if (max >= 5000) {
 				let mean = this.average(posTotal);
 				let stddev = this.stddev(posTotal);
-				result.clip = max > (mean + 3 * stddev) ?
-					Math.ceil((mean + 2 * stddev) / 1000) * 1000 :
-					null;
+				if (max > (mean + 3 * stddev)) {
+					let clipLimit = Math.max(...posTotal.filter(value => value <= (mean + 2 * stddev)));
+					result.clip = Math.ceil(clipLimit / 1000) * 1000;
+				}
 			}
 			return result;
 		}

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -2030,12 +2030,14 @@ Module.register("MMM-Powerwall", {
 				),
 				new Array(result.datasets[0].data.length).fill(0)
 			);
-			let mean = this.average(posTotal);
-			let stddev = this.stddev(posTotal);
 			let max = Math.max(...posTotal);
-			result.clip = max > (mean + 3 * stddev) ?
-				Math.ceil((mean + 2 * stddev) / 1000) * 1000 :
-				null;
+			if (max >= 5000) {
+				let mean = this.average(posTotal);
+				let stddev = this.stddev(posTotal);
+				result.clip = max > (mean + 3 * stddev) ?
+					Math.ceil((mean + 2 * stddev) / 1000) * 1000 :
+					null;
+			}
 			return result;
 		}
 		else {

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -2040,7 +2040,7 @@ Module.register("MMM-Powerwall", {
 					(value, index) => 
 						[...series].
 							sort((a, b) => a.order - b.order).
-							map(source => Math.abs(source.data.at(index))).
+							map(source => Math.abs(source.data[index])).
 							filter(e => e && e > 1).
 							slice(0,-1).
 							reduce((s,v) => s+v, 0)
@@ -2051,7 +2051,9 @@ Module.register("MMM-Powerwall", {
 						...exceptLastShown(sources),
 						...exceptLastShown(sinks)
 					);
-					result.clip = Math.ceil(clipLimit / 1000) * 1000;
+					if(max > clipLimit) {
+						result.clip = Math.ceil(clipLimit / 1000) * 1000;
+					}
 				}
 			}
 			return result;

--- a/MMM-Powerwall.js
+++ b/MMM-Powerwall.js
@@ -1898,7 +1898,13 @@ Module.register("MMM-Powerwall", {
 							ticks: {
 								callback: function (value, index, values) {
 									if (value % 1000 == 0) {
-										return Math.abs(value) / 1000;
+										value = Math.abs(value);
+										let result = value / 1000;
+										let clip = this.max;
+										if (clip && value >= clip) {
+											result = ">" + result;
+										}
+										return result;
 									}
 								},
 								color: "white",


### PR DESCRIPTION
Depending on one's TWCManager and EV charging setup, brief periods of EV charging can swamp the rest of the data.  This change makes PowerLine consider whether your data has outliers, and if so, clip the graph so that the majority of the data is appropriately scaled.  (The top tick mark gains a ">X" indicator to indicate this is happening.)

Specifically, it calculates the mean and standard deviation of the power usage; if any periods are more than three standard deviations above the mean, it clips the graph at two standard deviations.  This seems to produce acceptable results, but I plan to live with it for a few days and see how it behaves, particularly on a sunny day.  Others are welcome to try it and give feedback as well.