### PR TITLE
Migrate from deprecated /history to /calendar_history API

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -17,6 +17,17 @@ const spawn = require("await-spawn");
 const mqtt = require("async-mqtt");
 const mutex = require("async-mutex").Mutex;
 
+// Helper function for calendar_history date parameters
+// Tesla deprecated /history endpoint (HTTP 410) - must use /calendar_history
+function getCalendarHistoryDates() {
+	const now = new Date();
+	// Use UTC dates to avoid timezone conversion issues
+	const startDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1, 0, 0, 0));
+	const endDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0));
+	const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || "America/New_York";
+	return { startDate: startDate.toISOString(), endDate: endDate.toISOString(), tz };
+}
+
 const MI_KM_FACTOR = 1.609344;
 
 module.exports = NodeHelper.create({
@@ -1050,22 +1061,34 @@ module.exports = NodeHelper.create({
 	},
 
 	doTeslaApiGetEnergy: async function (username, siteID) {
-		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID + "/history?period=day&kind=energy";
+		const { startDate, endDate, tz } = getCalendarHistoryDates();
+		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID +
+			"/calendar_history?kind=energy&period=day&start_date=" + startDate +
+			"&end_date=" + endDate + "&time_zone=" + encodeURIComponent(tz);
 		await this.doTeslaApi(url, username, "siteID", siteID, this.energy, "EnergyData", "time_series", "energy");
 	},
 
 	doTeslaApiGetPowerHistory: async function (username, siteID) {
-		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID + "/history?period=day&kind=power";
+		const { startDate, endDate, tz } = getCalendarHistoryDates();
+		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID +
+			"/calendar_history?kind=power&period=day&start_date=" + startDate +
+			"&end_date=" + endDate + "&time_zone=" + encodeURIComponent(tz);
 		await this.doTeslaApi(url, username, "siteID", siteID, this.powerHistory, "PowerHistory", "time_series", "powerHistory");
 	},
 
 	doTeslaApiGetBackupHistory: async function (username, siteID) {
-		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID + "/history?kind=backup";
+		const { startDate, endDate, tz } = getCalendarHistoryDates();
+		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID +
+			"/calendar_history?kind=backup&start_date=" + startDate +
+			"&end_date=" + endDate + "&time_zone=" + encodeURIComponent(tz);
 		await this.doTeslaApi(url, username, "siteID", siteID, this.backup, "Backup", "events", "backup");
 	},
 
 	doTeslaApiGetSelfConsumption: async function (username, siteID) {
-		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID + "/history?kind=self_consumption&period=day";
+		const { startDate, endDate, tz } = getCalendarHistoryDates();
+		url = "https://owner-api.teslamotors.com/api/1/energy_sites/" + siteID +
+			"/calendar_history?kind=self_consumption&period=day&start_date=" + startDate +
+			"&end_date=" + endDate + "&time_zone=" + encodeURIComponent(tz);
 		await this.doTeslaApi(url, username, "siteID", siteID, this.selfConsumption, "SelfConsumption", "time_series", "selfConsumption");
 	},
 


### PR DESCRIPTION
## Summary

Tesla has deprecated the `/history` endpoint (returns HTTP 410) and now requires the `/calendar_history` endpoint with explicit date parameters.

The old `/history` endpoint was returning:
```
{"error":"No longer supported: Use /v3/energy_site/energy_history instead","error_description":""}
```

## Changes

- Added `getCalendarHistoryDates()` helper function for generating UTC date parameters
- Updated `doTeslaApiGetEnergy` to use `/calendar_history`
- Updated `doTeslaApiGetPowerHistory` to use `/calendar_history`
- Updated `doTeslaApiGetBackupHistory` to use `/calendar_history`
- Updated `doTeslaApiGetSelfConsumption` to use `/calendar_history`

All endpoints now include the required `start_date`, `end_date`, and `time_zone` parameters in ISO 8601 format.

## Testing

Tested with Tesla Owner API - all endpoints now return `time_series` data successfully:
- `kind=energy` - returns energy consumption data
- `kind=power` - returns power flow data  
- `kind=self_consumption` - returns self-consumption metrics
- `kind=backup` - returns backup event history

Energy history charts now display correctly in the MagicMirror module.

## Related

This addresses the Tesla API deprecation that occurred in late 2024, where the legacy `/history` endpoint was retired in favor of the Fleet API's `/calendar_history` endpoint.